### PR TITLE
Fix missing Fabric build repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,10 @@ plugins {
 }
 version = project.mod_version
 group = project.maven_group
-repositories { mavenCentral() }
+repositories {
+  maven { url 'https://maven.fabricmc.net/' }
+  mavenCentral()
+}
 dependencies {
   minecraft "com.mojang:minecraft:${minecraft_version}"
   mappings loom.yarnMappings("${yarn_mappings}")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        maven { url 'https://maven.fabricmc.net/' }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'k8mrp'


### PR DESCRIPTION
## Summary
- Add Fabric Maven repositories so Loom plugin and dependencies can resolve
- Configure plugin management in settings for Fabric Loom

## Testing
- `gradle build` *(fails: Plugin [id: 'fabric-loom', version: '1.6-SNAPSHOT'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_68968202c1e4832599e800ed3d4dea6b